### PR TITLE
Fix typo and use single quotes in projections

### DIFF
--- a/autoload/laravel/projectionist.vim
+++ b/autoload/laravel/projectionist.vim
@@ -11,222 +11,222 @@ endfunction
 
 function! laravel#projectionist#append() abort
   let projections = {
-        \ "*": {
-        \   "start": "homestead ssh",
-        \   "console": [laravel#app().makeprg(), 'tinker'],
-        \   "framework": "laravel",
+        \ '*': {
+        \   'start': 'homestead ssh',
+        \   'console': [laravel#app().makeprg(), 'tinker'],
+        \   'framework': 'laravel',
         \ },
-        \ "bootstrap/*.php": {
-        \   "type": "bootstrap",
+        \ 'bootstrap/*.php': {
+        \   'type': 'bootstrap',
         \ },
-        \ "config/*.php": {
-        \   "type": "config",
-        \   "template": [
-        \     "<?php",
-        \     "",
-        \     "return [",
-        \     "    //",
-        \     "];",
+        \ 'config/*.php': {
+        \   'type': 'config',
+        \   'template': [
+        \     '<?php',
+        \     '',
+        \     'return [',
+        \     '    //',
+        \     '];',
         \   ],
         \ },
-        \ "config/app.php": {
-        \   "type": "config",
+        \ 'config/app.php': {
+        \   'type': 'config',
         \ },
-        \ "app/*.php": {
-        \   "type": "lib",
-        \   "template": [
-        \     "<?php",
-        \     "",
-        \     "namespace {namespace};",
-        \     "",
-        \     "class {basename}",
-        \     "{open}",
-        \     "    //",
-        \     "{close}",
+        \ 'app/*.php': {
+        \   'type': 'lib',
+        \   'template': [
+        \     '<?php',
+        \     '',
+        \     'namespace {namespace};',
+        \     '',
+        \     'class {basename}',
+        \     '{open}',
+        \     '    //',
+        \     '{close}',
         \   ],
         \ },
-        \ "app/Http/Controllers/*.php": {
-        \   "type": "controller",
-        \   "template": [
-        \     "<?php",
-        \     "",
-        \     "namespace {namespace};",
-        \     "",
-        \     "class {basename} extends Controller",
-        \     "{open}",
-        \     "    //",
-        \     "{close}",
+        \ 'app/Http/Controllers/*.php': {
+        \   'type': 'controller',
+        \   'template': [
+        \     '<?php',
+        \     '',
+        \     'namespace {namespace};',
+        \     '',
+        \     'class {basename} extends Controller',
+        \     '{open}',
+        \     '    //',
+        \     '{close}',
         \   ],
         \ },
-        \ "app/Http/Controllers/Controller.php": {
-        \   "type": "controller",
+        \ 'app/Http/Controllers/Controller.php': {
+        \   'type': 'controller',
         \ },
-        \ "app/Http/Middleware/*.php": {
-        \   "type": "middleware",
+        \ 'app/Http/Middleware/*.php': {
+        \   'type': 'middleware',
         \ },
-        \ "app/Http/Kernel.php": {
-        \   "type": "middleware",
+        \ 'app/Http/Kernel.php': {
+        \   'type': 'middleware',
         \ },
-        \ "app/Http/Requests/*.php": {
-        \   "type": "request",
+        \ 'app/Http/Requests/*.php': {
+        \   'type': 'request',
         \ },
-        \ "app/Events/*.php": {
-        \   "type": "event",
-        \   "alternate": "app/Listeners/{}.php",
+        \ 'app/Events/*.php': {
+        \   'type': 'event',
+        \   'alternate': 'app/Listeners/{}.php',
         \ },
-        \ "app/Events/Event.php": {
-        \   "type": "event",
+        \ 'app/Events/Event.php': {
+        \   'type': 'event',
         \ },
-        \ "app/Exceptions/*.php": {
-        \   "type": "exception",
+        \ 'app/Exceptions/*.php': {
+        \   'type': 'exception',
         \ },
-        \ "app/Exceptions/Handler.php": {
-        \   "type": "exception",
+        \ 'app/Exceptions/Handler.php': {
+        \   'type': 'exception',
         \ },
-        \ "app/Providers/*.php": {
-        \   "type": "provider",
+        \ 'app/Providers/*.php': {
+        \   'type': 'provider',
         \ },
-        \ "database/factories/*.php": {
-        \   "type": "factory",
+        \ 'database/factories/*.php': {
+        \   'type': 'factory',
         \ },
-        \ "database/factories/ModelFactory.php": {
-        \   "type": "factory",
+        \ 'database/factories/ModelFactory.php': {
+        \   'type': 'factory',
         \ },
-        \ "database/migrations/*.php": {
-        \   "type": "migration",
+        \ 'database/migrations/*.php': {
+        \   'type': 'migration',
         \ },
-        \ "database/seeds/*.php": {
-        \   "type": "seeder",
+        \ 'database/seeds/*.php': {
+        \   'type': 'seeder',
         \ },
-        \ "database/seeds/DatabaseSeeder.php": {
-        \   "type": "seeder",
+        \ 'database/seeds/DatabaseSeeder.php': {
+        \   'type': 'seeder',
         \ },
-        \ "tests/*.php": {
-        \   "type": "test",
+        \ 'tests/*.php': {
+        \   'type': 'test',
         \ },
-        \ "tests/TestCase.php": {
-        \   "type": "test",
-        \   "alternate": "phpunit.xml",
+        \ 'tests/TestCase.php': {
+        \   'type': 'test',
+        \   'alternate': 'phpunit.xml',
         \ },
-        \ "phpunit.xml": {
-        \   "alternate": "test/TestCase.php",
+        \ 'phpunit.xml': {
+        \   'alternate': 'test/TestCase.php',
         \ },
-        \ "resources/lang/*.php": {
-        \   "type": "language",
+        \ 'resources/lang/*.php': {
+        \   'type': 'language',
         \ },
-        \ "resources/assets/*": {
-        \   "type": "asset",
+        \ 'resources/assets/*': {
+        \   'type': 'asset',
         \ },
-        \ "resources/views/*.blade.php": {
-        \   "type": "view",
+        \ 'resources/views/*.blade.php': {
+        \   'type': 'view',
         \ },
-        \ "README.md": {
-        \   "type": "doc",
+        \ 'README.md': {
+        \   'type': 'doc',
         \ }}
 
   if laravel#app().has('dotenv')
-    let projections[".env.example"] = {
-          \   "type": "env",
-          \   "alternate": ".env",
+    let projections['.env.example'] = {
+          \   'type': 'env',
+          \   'alternate': '.env',
           \ }
 
-    let projections[".env"] = {
-          \   "type": "env",
-          \   "alternate": ".env.example",
+    let projections['.env'] = {
+          \   'type': 'env',
+          \   'alternate': '.env.example',
           \ }
   endif
 
   if laravel#app().has('jobs')
-    let projections["app/Jobs/*.php"] = {
-          \   "type": "job",
+    let projections['app/Jobs/*.php'] = {
+          \   'type': 'job',
           \ }
 
-    let projections["app/Jobs/Job.php"] = {
-          \   "type": "job",
+    let projections['app/Jobs/Job.php'] = {
+          \   'type': 'job',
           \ }
 
-    let projections["app/Console/Commands/*.php"] = {
-          \   "type": "command",
+    let projections['app/Console/Commands/*.php'] = {
+          \   'type': 'command',
           \ }
 
-    let projections["app/Console/Kernel.php"] = {
-          \   "type": "command",
+    let projections['app/Console/Kernel.php'] = {
+          \   'type': 'command',
           \ }
   elseif laravel#app().has('commands')
-    let projections["app/Commands/*.php"] = {
-          \   "type": "command",
+    let projections['app/Commands/*.php'] = {
+          \   'type': 'command',
           \ }
 
-    let projections["app/Console/Commands/*.php"] = {
-          \   "type": "console",
+    let projections['app/Console/Commands/*.php'] = {
+          \   'type': 'console',
           \ }
 
-    let projections["app/Console/Kernel.php"] = {
-          \   "type": "console",
+    let projections['app/Console/Kernel.php'] = {
+          \   'type': 'console',
           \ }
   endif
 
   if laravel#app().has('listeners')
-    let projections["app/Listeners/*.php"] = {
-          \   "type": "listener",
-          \   "alternate": "app/Events/{}.php",
+    let projections['app/Listeners/*.php'] = {
+          \   'type': 'listener',
+          \   'alternate': 'app/Events/{}.php',
           \ }
   elseif laravel#app().has('handlers')
-    let projections["app/Handlers/*.php"] = {
-          \   "type": "handler",
-          \   "alternate": "app/Events/{}.php",
+    let projections['app/Handlers/*.php'] = {
+          \   'type': 'handler',
+          \   'alternate': 'app/Events/{}.php',
           \ }
   endif
 
   if laravel#app().has('models')
-    let projections["app/Models/*.php"] = {
-          \   "type": "model",
-          \   "template": [
-          \     "<?php",
-          \     "",
-          \     "namespace {namespace};",
-          \     "",
-          \     "use Illuminate\Database\Eloquent\Model;",
-          \     "",
-          \     "class {basename} extends Model",
-          \     "{open}",
-          \     "    //",
-          \     "{close}",
+    let projections['app/Models/*.php'] = {
+          \   'type': 'model',
+          \   'template': [
+          \     '<?php',
+          \     '',
+          \     'namespace {namespace};',
+          \     '',
+          \     'use Illuminate\Database\Eloquent\Model;',
+          \     '',
+          \     'class {basename} extends Model',
+          \     '{open}',
+          \     '    //',
+          \     '{close}',
           \   ],
           \ }
   endif
 
   if laravel#app().has('policies')
-    let projections["app/Policies/*.php"] = {
-          \   "type": "policy",
-          \   "alternate": "app/Providers/AuthServiceProvider.php",
+    let projections['app/Policies/*.php'] = {
+          \   'type': 'policy',
+          \   'alternate': 'app/Providers/AuthServiceProvider.php',
           \ }
   endif
 
   if laravel#app().has('routes')
-    let projections["routes/*.php"] = {
-          \   "type": "routes",
-          \   "alternate": "app/Http/Kernel.php",
+    let projections['routes/*.php'] = {
+          \   'type': 'routes',
+          \   'alternate': 'app/Http/Kernel.php',
           \ }
   else
-    let projections["app/Http/routes.php"] = {
-          \   "type": "routes",
-          \   "alternate": "app/Http/Kernel.php",
+    let projections['app/Http/routes.php'] = {
+          \   'type': 'routes',
+          \   'alternate': 'app/Http/Kernel.php',
           \ }
   endif
 
   if laravel#app().has('traits')
-    let projections["app/Traits/*.php"] = {
-          \   "type": "trait",
-          \   "template": [
-          \     "<?php",
-          \     "",
-          \     "namespace {namespace};",
-          \     "",
-          \     "trait {basename}",
-          \     "{open}",
-          \     "    //",
-          \     "{close}",
+    let projections['app/Traits/*.php'] = {
+          \   'type': 'trait',
+          \   'template': [
+          \     '<?php',
+          \     '',
+          \     'namespace {namespace};',
+          \     '',
+          \     'trait {basename}',
+          \     '{open}',
+          \     '    //',
+          \     '{close}',
           \   ],
           \ }
   endif

--- a/autoload/laravel/projectionist.vim
+++ b/autoload/laravel/projectionist.vim
@@ -64,7 +64,7 @@ function! laravel#projectionist#append() abort
         \ "app/Http/Middleware/*.php": {
         \   "type": "middleware",
         \ },
-        \ "app/Http/Kernal.php": {
+        \ "app/Http/Kernel.php": {
         \   "type": "middleware",
         \ },
         \ "app/Http/Requests/*.php": {
@@ -149,7 +149,7 @@ function! laravel#projectionist#append() abort
           \   "type": "command",
           \ }
 
-    let projections["app/Console/Kernal.php"] = {
+    let projections["app/Console/Kernel.php"] = {
           \   "type": "command",
           \ }
   elseif laravel#app().has('commands')
@@ -161,7 +161,7 @@ function! laravel#projectionist#append() abort
           \   "type": "console",
           \ }
 
-    let projections["app/Console/Kernal.php"] = {
+    let projections["app/Console/Kernel.php"] = {
           \   "type": "console",
           \ }
   endif
@@ -206,12 +206,12 @@ function! laravel#projectionist#append() abort
   if laravel#app().has('routes')
     let projections["routes/*.php"] = {
           \   "type": "routes",
-          \   "alternate": "app/Http/Kernal.php",
+          \   "alternate": "app/Http/Kernel.php",
           \ }
   else
     let projections["app/Http/routes.php"] = {
           \   "type": "routes",
-          \   "alternate": "app/Http/Kernal.php",
+          \   "alternate": "app/Http/Kernel.php",
           \ }
   endif
 


### PR DESCRIPTION
A plugin like this was really missing for Laravel. Looks nice :smile: 

This fixes a typo and it fixes unescaped backslashes in the projectionist config.
