### PR TITLE
Fix opening the wrong file after make:model

### DIFF
--- a/autoload/laravel/artisan.vim
+++ b/autoload/laravel/artisan.vim
@@ -129,7 +129,7 @@ function! s:artisan_edit(command) abort
     return ''
   elseif a:command.name ==# 'console'
     let type = 'command'
-  elseif a:command.name ==# 'model' && !laravel#app().has('models')
+  elseif a:command.name ==# 'model'
     let type = 'lib'
   else
     let type = a:command.name


### PR DESCRIPTION
When there is a Models directory, the generated models from make:model will still be placed in the app directory, not in the app/Models directory.

So when you ran `:Artisan make:model Post`, it opened the new file 'app/Models/Post.php', instead of the generated file 'app/Post.php'.
