### PR TITLE
Add nvim-completion manager sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,20 @@ Vim support for [Laravel/Lumen 5+][laravel] projects. [![Release][release]](http
 | `:Eview`              | Blade templates                |
 
 * Enhanced `gf` command works on class names, template names, config and translation keys.
+* Complete view/route names in insert mode.
 * Use `:Console` to fire up a REPL (`artisan tinker`).
 
 ## Installation
 
 Laravel.vim has optional dependencies on [composer.vim][vim-composer],
-[dispatch.vim][dispatch] (the `:Console` command), and
-[projectionist.vim][projectionist] (navigation commands):
+[dispatch.vim][dispatch] (the `:Console` command),
+[projectionist.vim][projectionist] (navigation commands), and
+[nvim-completion-manager][ncm] (insert-mode completion):
 
-	Plug 'tpope/vim-dispatch'
-	Plug 'tpope/vim-projectionist'
-	Plug 'noahfrederick/vim-composer'
+	Plug 'tpope/vim-dispatch'             "| Optional
+	Plug 'tpope/vim-projectionist'        "|
+	Plug 'roxma/nvim-completion-manager'  "|
+	Plug 'noahfrederick/vim-composer'     "|
 	Plug 'noahfrederick/vim-laravel'
 
 ## Credits and License
@@ -67,4 +70,5 @@ See `:help license`.
 [vim-composer]: https://github.com/noahfrederick/vim-composer
 [projectionist]: https://github.com/tpope/vim-projectionist
 [dispatch]: https://github.com/tpope/vim-dispatch
+[ncm]: https://github.com/roxma/nvim-completion-manager
 [rails]: https://github.com/tpope/vim-rails

--- a/autoload/laravel.vim
+++ b/autoload/laravel.vim
@@ -415,6 +415,11 @@ call s:add_methods('cache', ['clear', 'get', 'set', 'has', 'needs'])
 
 let s:app_prototype.cache = s:cache_prototype
 
+augroup laravel_cache
+  autocmd!
+  autocmd BufWritePost routes.php,routes/*.php call laravel#cache_clear('routes')
+augroup END
+
 ""
 " Get namespace of buffer's file
 function! s:buffer_namespace() abort dict

--- a/autoload/laravel/completion.vim
+++ b/autoload/laravel/completion.vim
@@ -1,0 +1,21 @@
+" autoload/laravel/completion.vim - Completion sources
+" Maintainer: Noah Frederick
+
+function! laravel#completion#cm_routes(opt, ctx) abort
+  if exists('b:laravel_root')
+    call s:cm_complete(laravel#app().routes(), a:opt, a:ctx)
+  endif
+endfunction
+
+function! laravel#completion#cm_views(opt, ctx) abort
+  if exists('b:laravel_root')
+    call s:cm_complete(laravel#app().templates(), a:opt, a:ctx)
+  endif
+endfunction
+
+function! s:cm_complete(candidates, opt, ctx) abort
+  let matches = map(keys(a:candidates), '{"word": v:val, "info": a:candidates[v:val]}')
+  call cm#complete(a:opt, a:ctx, a:ctx['startcol'], matches)
+endfunction
+
+" vim: fdm=marker:sw=2:sts=2:et

--- a/plugin/laravel.vim
+++ b/plugin/laravel.vim
@@ -94,4 +94,31 @@ augroup laravel_projections
 augroup END
 
 " }}}
+" Completion {{{
+
+augroup laravel_completion
+  autocmd!
+  " Set up nvim-completion-manager sources
+  " :help NCM-source-examples
+  autocmd User CmSetup call cm#register_source({'name' : 'Laravel Route',
+        \ 'abbreviation': 'Route',
+        \ 'priority': 9,
+        \ 'scoping': 1,
+        \ 'scopes': ['php', 'blade'],
+        \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'cm_refresh_patterns': ['\broute\([''"]'],
+        \ 'cm_refresh': 'laravel#completion#cm_routes',
+        \ })
+  autocmd User CmSetup call cm#register_source({'name' : 'Laravel View',
+        \ 'abbreviation': 'View',
+        \ 'priority': 9,
+        \ 'scoping': 1,
+        \ 'scopes': ['php', 'blade'],
+        \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'cm_refresh_patterns': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
+        \ 'cm_refresh': 'laravel#completion#cm_views',
+        \ })
+augroup END
+
+" }}}
 " vim: fdm=marker:sw=2:sts=2:et


### PR DESCRIPTION
Adds completion sources for view and route names. If you have [nvim-completion-manager](https://github.com/roxma/nvim-completion-manager) installed, these sources will be registered automatically. In a buffer belonging to a Laravel project, typing e.g.

    view('|

or

    route('|

will offer completion candidates based on the app's views and routes.