### PR TITLE
Update ncm to ncm2

### DIFF
--- a/autoload/laravel.vim
+++ b/autoload/laravel.vim
@@ -310,7 +310,7 @@ endfunction
 "   { 'route.name': 'GET|POST route/url', ... }
 function! s:app_routes() abort dict
   if self.cache.needs('routes')
-    let lines = laravel#artisan#capture('route:list')
+    let lines = laravel#artisan#capture(laravel#app(), 'route:list')
     call filter(lines, 'v:val =~# ''^| ''')
     " Remove header line
     call remove(lines, 0)

--- a/autoload/laravel/artisan.vim
+++ b/autoload/laravel/artisan.vim
@@ -57,7 +57,7 @@ endfunction
 
 ""
 " Get output from Artisan with {args} in project's root directory.
-function! s:artisan_capture(app, args) abort
+function! laravel#artisan#capture(app, args) abort
   try
     let cwd = s:cd(a:app.path())
     let result = systemlist(a:app.makeprg(a:args))
@@ -72,7 +72,7 @@ endfunction
 " Get Dict from artisan list --format=json.
 function! s:artisan_json(app) abort
   if a:app.cache.needs('artisan_json')
-    let lines = s:artisan_capture(a:app, ['list', '--format=json'])
+    let lines = laravel#artisan#capture(a:app, ['list', '--format=json'])
 
     let json = {}
 

--- a/autoload/laravel/completion.vim
+++ b/autoload/laravel/completion.vim
@@ -1,21 +1,21 @@
 " autoload/laravel/completion.vim - Completion sources
 " Maintainer: Noah Frederick
 
-function! laravel#completion#cm_routes(opt, ctx) abort
+function! laravel#completion#cm_routes(ctx) abort
   if exists('b:laravel_root')
-    call s:cm_complete(laravel#app().routes(), a:opt, a:ctx)
+    call s:cm_complete(laravel#app().routes(), a:ctx)
   endif
 endfunction
 
-function! laravel#completion#cm_views(opt, ctx) abort
+function! laravel#completion#cm_views(ctx) abort
   if exists('b:laravel_root')
-    call s:cm_complete(laravel#app().templates(), a:opt, a:ctx)
+    call s:cm_complete(laravel#app().templates(), a:ctx)
   endif
 endfunction
 
-function! s:cm_complete(candidates, opt, ctx) abort
+function! s:cm_complete(candidates, ctx) abort
   let matches = map(keys(a:candidates), '{"word": v:val, "info": a:candidates[v:val]}')
-  call cm#complete(a:opt, a:ctx, a:ctx['startcol'], matches)
+  call ncm2#complete(a:ctx, a:ctx['startccol'], matches)
 endfunction
 
 " vim: fdm=marker:sw=2:sts=2:et

--- a/autoload/laravel/completion.vim
+++ b/autoload/laravel/completion.vim
@@ -1,19 +1,36 @@
 " autoload/laravel/completion.vim - Completion sources
 " Maintainer: Noah Frederick
 
-function! laravel#completion#cm_routes(ctx) abort
+function! laravel#completion#cm_routes(opt, ctx) abort
   if exists('b:laravel_root')
-    call s:cm_complete(laravel#app().routes(), a:ctx)
+    call s:cm_complete(laravel#app().routes(), a:opt, a:ctx)
   endif
 endfunction
 
-function! laravel#completion#cm_views(ctx) abort
+function! laravel#completion#cm_views(opt, ctx) abort
   if exists('b:laravel_root')
-    call s:cm_complete(laravel#app().templates(), a:ctx)
+    call s:cm_complete(laravel#app().templates(), a:opt, a:ctx)
   endif
 endfunction
 
-function! s:cm_complete(candidates, ctx) abort
+function! s:cm_complete(candidates, opt, ctx) abort
+  let matches = map(keys(a:candidates), '{"word": v:val, "info": a:candidates[v:val]}')
+  call cm#complete(a:opt, a:ctx, a:ctx['startcol'], matches)
+endfunction
+
+function! laravel#completion#ncm2_routes(ctx) abort
+  if exists('b:laravel_root')
+    call s:ncm2_complete(laravel#app().routes(), a:ctx)
+  endif
+endfunction
+
+function! laravel#completion#ncm2_views(ctx) abort
+  if exists('b:laravel_root')
+    call s:ncm2_complete(laravel#app().templates(), a:ctx)
+  endif
+endfunction
+
+function! s:ncm2_complete(candidates, ctx) abort
   let matches = map(keys(a:candidates), '{"word": v:val, "info": a:candidates[v:val]}')
   call ncm2#complete(a:ctx, a:ctx['startccol'], matches)
 endfunction

--- a/plugin/laravel.vim
+++ b/plugin/laravel.vim
@@ -101,7 +101,28 @@ augroup laravel_completion
   autocmd!
   " Set up nvim-completion-manager sources
   " :help NCM-source-examples
-  au User Ncm2Plugin call ncm2#register_source({
+  autocmd User CmSetup call cm#register_source({'name' : 'Laravel Route',
+        \ 'abbreviation': 'Route',
+        \ 'priority': 9,
+        \ 'scoping': 1,
+        \ 'scopes': ['php', 'blade'],
+        \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'cm_refresh_patterns': ['\broute\([''"]'],
+        \ 'cm_refresh': 'laravel#completion#cm_routes',
+        \ })
+  autocmd User CmSetup call cm#register_source({'name' : 'Laravel View',
+        \ 'abbreviation': 'View',
+        \ 'priority': 9,
+        \ 'scoping': 1,
+        \ 'scopes': ['php', 'blade'],
+        \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'cm_refresh_patterns': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
+        \ 'cm_refresh': 'laravel#completion#cm_views',
+        \ })
+
+  " Set up ncm2 sources
+  " :help ncm2#register_source-example
+  autocmd User Ncm2Plugin call ncm2#register_source({
         \ 'name' : 'Laravel Route',
         \ 'priority': 9,
         \ 'subscope_enable': 1,
@@ -109,9 +130,9 @@ augroup laravel_completion
         \ 'mark': 'Route',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
         \ 'complete_pattern': ['\broute\([''"]'],
-        \ 'on_complete': 'laravel#completion#cm_routes',
+        \ 'on_complete': 'laravel#completion#ncm2_routes',
         \ })
-  au User Ncm2Plugin call ncm2#register_source({
+  autocmd User Ncm2Plugin call ncm2#register_source({
         \ 'name' : 'Laravel View',
         \ 'priority': 9,
         \ 'subscope_enable': 1,
@@ -119,7 +140,7 @@ augroup laravel_completion
         \ 'mark': 'View',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
         \ 'complete_pattern': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
-        \ 'on_complete': 'laravel#completion#cm_views',
+        \ 'on_complete': 'laravel#completion#ncm2_views',
         \ })
 augroup END
 

--- a/plugin/laravel.vim
+++ b/plugin/laravel.vim
@@ -101,23 +101,25 @@ augroup laravel_completion
   autocmd!
   " Set up nvim-completion-manager sources
   " :help NCM-source-examples
-  autocmd User CmSetup call cm#register_source({'name' : 'Laravel Route',
-        \ 'abbreviation': 'Route',
+  au User Ncm2Plugin call ncm2#register_source({
+        \ 'name' : 'Laravel Route',
         \ 'priority': 9,
-        \ 'scoping': 1,
-        \ 'scopes': ['php', 'blade'],
+        \ 'subscope_enable': 1,
+        \ 'scope': ['php','blade'],
+        \ 'mark': 'Route',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
-        \ 'cm_refresh_patterns': ['\broute\([''"]'],
-        \ 'cm_refresh': 'laravel#completion#cm_routes',
+        \ 'complete_pattern': ['\broute\([''"]'],
+        \ 'on_complete': 'laravel#completion#cm_routes',
         \ })
-  autocmd User CmSetup call cm#register_source({'name' : 'Laravel View',
-        \ 'abbreviation': 'View',
+  au User Ncm2Plugin call ncm2#register_source({
+        \ 'name' : 'Laravel View',
         \ 'priority': 9,
-        \ 'scoping': 1,
-        \ 'scopes': ['php', 'blade'],
+        \ 'subscope_enable': 1,
+        \ 'scope': ['php','blade'],
+        \ 'mark': 'View',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
-        \ 'cm_refresh_patterns': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
-        \ 'cm_refresh': 'laravel#completion#cm_views',
+        \ 'complete_pattern': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
+        \ 'on_complete': 'laravel#completion#cm_views',
         \ })
 augroup END
 

--- a/plugin/laravel.vim
+++ b/plugin/laravel.vim
@@ -123,20 +123,20 @@ augroup laravel_completion
   " Set up ncm2 sources
   " :help ncm2#register_source-example
   autocmd User Ncm2Plugin call ncm2#register_source({
-        \ 'name' : 'Laravel Route',
+        \ 'name': 'Laravel Route',
         \ 'priority': 9,
         \ 'subscope_enable': 1,
-        \ 'scope': ['php','blade'],
+        \ 'scope': ['php', 'blade'],
         \ 'mark': 'Route',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
         \ 'complete_pattern': ['\broute\([''"]'],
         \ 'on_complete': 'laravel#completion#ncm2_routes',
         \ })
   autocmd User Ncm2Plugin call ncm2#register_source({
-        \ 'name' : 'Laravel View',
+        \ 'name': 'Laravel View',
         \ 'priority': 9,
         \ 'subscope_enable': 1,
-        \ 'scope': ['php','blade'],
+        \ 'scope': ['php', 'blade'],
         \ 'mark': 'View',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
         \ 'complete_pattern': ['\bview\([''"]', '@(component|extends|include)\([''"]'],

--- a/plugin/laravel.vim
+++ b/plugin/laravel.vim
@@ -129,6 +129,7 @@ augroup laravel_completion
         \ 'scope': ['php', 'blade'],
         \ 'mark': 'Route',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'complete_length': -1,
         \ 'complete_pattern': ['\broute\([''"]'],
         \ 'on_complete': 'laravel#completion#ncm2_routes',
         \ })
@@ -139,6 +140,7 @@ augroup laravel_completion
         \ 'scope': ['php', 'blade'],
         \ 'mark': 'View',
         \ 'word_pattern': '[A-Za-z0-9_.:-]+',
+        \ 'complete_length': -1,
         \ 'complete_pattern': ['\bview\([''"]', '@(component|extends|include)\([''"]'],
         \ 'on_complete': 'laravel#completion#ncm2_views',
         \ })


### PR DESCRIPTION
Note: this will break for anybody that currently uses ncm. I wasn't sure the right way to handle this - add a whole new group of stuff for ncm2, or just update it. I figured I would update it first since that was the easier path.

I tried to run the tests but `bundle install` failed, stating: `Could not locate Gemfile`

In order to get the routes completion working for ncm2, I had to make
the `capture()` function available from anywhere, and I needed to call it
with 2 arguments intead of 1.

