### PR TITLE
Add test suite with vader.vim

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-.vim-flavor
-
 # Packaged plug-in dir
 pkg/
+
+# Fixtures installed by CI
+/test/fixtures/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,11 @@
-language: vim
+language: php
+php:
+  - 7.4
 
 before_script: |
   git clone https://github.com/junegunn/vader.vim.git
   git clone https://github.com/tpope/vim-projectionist.git
   git clone https://github.com/noahfrederick/vim-composer.git
+  composer create-project laravel/laravel:^8.0 test/fixtures/laravel-8
 script: |
-  vim -Nu <(cat << VIMRC
-  filetype off
-  set rtp+=vader.vim
-  set rtp+=vim-projectionist
-  set rtp+=vim-composer
-  set rtp+=.
-  filetype plugin indent on
-  syntax enable
-  VIMRC) -c 'Vader! test/*' > /dev/null
+  vim -Nu test/fixtures/init.vim -c 'Vader! test/*' > /dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: vim
+
+before_script: |
+  git clone https://github.com/junegunn/vader.vim.git
+  git clone https://github.com/tpope/vim-projectionist.git
+  git clone https://github.com/noahfrederick/vim-composer.git
+script: |
+  vim -Nu <(cat << VIMRC
+  filetype off
+  set rtp+=vader.vim
+  set rtp+=vim-projectionist
+  set rtp+=vim-composer
+  set rtp+=.
+  filetype plugin indent on
+  syntax enable
+  VIMRC) -c 'Vader! test/*' > /dev/null

--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 Vim support for [Laravel/Lumen 5+][laravel] projects.
 
+[![Build Status][buildimg]](https://travis-ci.org/noahfrederick/vim-laravel)
 [![Release][release]](https://github.com/noahfrederick/vim-laravel/releases)
 
 > :warning: This is a prerelease version, which may introduce breaking changes.
 
 [laravel]:  https://laravel.com/
+[buildimg]: https://img.shields.io/travis/noahfrederick/vim-laravel/master.svg
 [release]:  https://img.shields.io/github/tag/noahfrederick/vim-laravel.svg?maxAge=2592000
 
 ## Features

--- a/Rakefile
+++ b/Rakefile
@@ -5,17 +5,9 @@ require 'json'
 
 plugin = JSON.load(File.new('addon-info.json'))
 
-desc 'Target for CI server'
-task ci: [:dump, :test]
-
-desc 'Dump Vim\'s version info'
-task :dump do
-  sh 'vim --version'
-end
-
-desc 'Run tests with vspec'
+desc 'Run tests with vader'
 task :test do
-  sh 'bundle exec vim-flavor test'
+  sh 'vim -c "Vader! test/*"'
 end
 
 desc 'Rebuild the documentation with vimdoc'

--- a/autoload/laravel.vim
+++ b/autoload/laravel.vim
@@ -214,13 +214,13 @@ function! s:has_framework(feature)
   elseif name == 'lumen'
     let package = 'laravel/lumen-framework'
   else
-    return v:false
+    return 0
   endif
 
   try
-    return composer#project().is_installed(package, comparator, ver)
+    return !!composer#project().is_installed(package, comparator, ver)
   catch /^Vim\%((\a\+)\)\=:E117/
-    return v:false
+    return 0
   endtry
 endfunction
 

--- a/autoload/laravel/projectionist.vim
+++ b/autoload/laravel/projectionist.vim
@@ -19,6 +19,9 @@ function! laravel#projectionist#append() abort
         \ 'bootstrap/*.php': {
         \   'type': 'bootstrap',
         \ },
+        \ 'bootstrap/app.php': {
+        \   'type': 'bootstrap',
+        \ },
         \ 'config/*.php': {
         \   'type': 'config',
         \   'template': [
@@ -144,6 +147,13 @@ function! laravel#projectionist#append() abort
         \ 'app/Exceptions/Handler.php': {
         \   'type': 'exception',
         \ },
+        \ 'app/Notifications/*.php': {
+        \   'type': 'notification',
+        \ },
+        \ 'app/Policies/*.php': {
+        \   'type': 'policy',
+        \   'alternate': 'app/Providers/AuthServiceProvider.php',
+        \ },
         \ 'app/Providers/*.php': {
         \   'type': 'provider',
         \ },
@@ -241,14 +251,14 @@ function! laravel#projectionist#append() abort
           \ }
   endif
 
-  if laravel#app().has('listeners')
-    let projections['app/Listeners/*.php'] = {
-          \   'type': 'listener',
-          \   'alternate': 'app/Events/{}.php',
-          \ }
-  elseif laravel#app().has('handlers')
+  if laravel#app().has('handlers')
     let projections['app/Handlers/*.php'] = {
           \   'type': 'handler',
+          \   'alternate': 'app/Events/{}.php',
+          \ }
+  else
+    let projections['app/Listeners/*.php'] = {
+          \   'type': 'listener',
           \   'alternate': 'app/Events/{}.php',
           \ }
   endif
@@ -268,19 +278,6 @@ function! laravel#projectionist#append() abort
           \     '    //',
           \     '{close}',
           \   ],
-          \ }
-  endif
-
-  if laravel#app().has('notifications')
-    let projections['app/Notifications/*.php'] = {
-          \   'type': 'notification',
-          \ }
-  endif
-
-  if laravel#app().has('policies')
-    let projections['app/Policies/*.php'] = {
-          \   'type': 'policy',
-          \   'alternate': 'app/Providers/AuthServiceProvider.php',
           \ }
   endif
 

--- a/test/artisan.vader
+++ b/test/artisan.vader
@@ -2,7 +2,7 @@ Before (in a laravel buffer):
   edit test/fixtures/laravel-8/.env
 
 Execute (generate model file):
-  Artisan make:model Example
+  silent Artisan make:model Example
 
 Then (editing model file):
   AssertEqual expand('%'), 'test/fixtures/laravel-8/app/Models/Example.php'

--- a/test/artisan.vader
+++ b/test/artisan.vader
@@ -1,0 +1,8 @@
+Before (in a laravel buffer):
+  edit test/fixtures/laravel-8/.env
+
+Execute (generate model file):
+  Artisan make:model Example
+
+Then (editing model file):
+  AssertEqual expand('%'), 'test/fixtures/laravel-8/app/Models/Example.php'

--- a/test/feature_detection.vader
+++ b/test/feature_detection.vader
@@ -1,0 +1,69 @@
+Before (in a laravel 8 buffer):
+  edit test/fixtures/laravel-8/.env
+
+After (clean up empty dirs):
+  !find . -type d -empty -delete
+
+Execute (has framework):
+  AssertEqual laravel#app().has('lumen'), 0
+  AssertEqual laravel#app().has('laravel'), 1
+
+Execute (has version):
+  AssertEqual laravel#app().has('laravel 7'), 0
+  AssertEqual laravel#app().has('laravel 8'), 1
+  AssertEqual laravel#app().has('laravel == 7'), 0
+  AssertEqual laravel#app().has('laravel == 8'), 1
+
+Execute (has version range):
+  AssertEqual laravel#app().has('laravel < 7'), 0
+  AssertEqual laravel#app().has('laravel > 7'), 1
+
+Execute (has feature artisan):
+  AssertEqual laravel#app().has('artisan'), 1
+
+Execute (has feature blade):
+  AssertEqual laravel#app().has('blade'), 1
+
+Execute (has feature commands):
+  AssertEqual laravel#app().has('commands'), 0
+
+Execute (has feature dotenv):
+  AssertEqual laravel#app().has('dotenv'), 1
+
+Execute (has feature gulp):
+  AssertEqual laravel#app().has('gulp'), 0
+
+Execute (has feature handlers):
+  AssertEqual laravel#app().has('handlers'), 0
+
+Execute (has feature jobs):
+  AssertEqual laravel#app().has('jobs'), 0
+
+Execute (has feature listeners):
+  AssertEqual laravel#app().has('listeners'), 0
+
+Execute (has feature mail):
+  AssertEqual laravel#app().has('mail'), 0
+
+Execute (has feature models):
+  AssertEqual laravel#app().has('models'), 1
+
+Execute (has feature namespaced-tests):
+  AssertEqual laravel#app().has('namespaced-tests'), 1
+
+Execute (has feature notifications):
+  AssertEqual laravel#app().has('notifications'), 0
+
+Execute (has feature policies):
+  AssertEqual laravel#app().has('policies'), 0
+
+Execute (has feature scopes):
+  AssertEqual laravel#app().has('scopes'), 0
+
+Execute (has feature traits):
+  AssertEqual laravel#app().has('traits'), 0
+
+Execute (has arbitrary path):
+  AssertEqual laravel#app().has('app/DoesNotExist'), 0
+  AssertEqual laravel#app().has('app/Http'), 1
+  AssertEqual laravel#app().has('app/Http|app/DoesNotExist'), 1

--- a/test/feature_detection.vader
+++ b/test/feature_detection.vader
@@ -2,7 +2,7 @@ Before (in a laravel 8 buffer):
   edit test/fixtures/laravel-8/.env
 
 After (clean up empty dirs):
-  !find . -type d -empty -delete
+  silent !find . -type d -empty -delete
 
 Execute (has framework):
   AssertEqual laravel#app().has('lumen'), 0

--- a/test/fixtures/init.vim
+++ b/test/fixtures/init.vim
@@ -1,0 +1,7 @@
+filetype off
+set rtp+=vader.vim
+set rtp+=vim-projectionist
+set rtp+=vim-composer
+set rtp+=.
+filetype plugin indent on
+syntax enable

--- a/test/initialization.vader
+++ b/test/initialization.vader
@@ -1,0 +1,2 @@
+Execute (sets guard variable):
+  AssertEqual g:loaded_laravel, 1

--- a/test/initialization.vader
+++ b/test/initialization.vader
@@ -1,2 +1,6 @@
 Execute (sets guard variable):
   AssertEqual g:loaded_laravel, 1
+
+Execute (Laravel root is detected):
+  edit test/fixtures/laravel-8/.env
+  AssertEqual b:laravel_root, fnamemodify('test/fixtures/laravel-8', ':p:h')

--- a/test/navigation.vader
+++ b/test/navigation.vader
@@ -1,0 +1,163 @@
+Before (in a laravel buffer):
+  edit test/fixtures/laravel-8/.env
+  execute 'cd' b:laravel_root
+
+Execute (edit bootstrap file):
+  Elib Foo/Bar
+  AssertEqual expand('%'), 'app/Foo/Bar.php'
+
+Execute (edit bootstrap file):
+  Ebootstrap example
+  AssertEqual expand('%'), 'bootstrap/example.php'
+
+Execute (edit default bootstrap file):
+  Ebootstrap
+  AssertEqual expand('%'), 'bootstrap/app.php'
+
+Execute (edit config file):
+  Econfig example
+  AssertEqual expand('%'), 'config/example.php'
+
+Execute (edit default config file):
+  Econfig
+  AssertEqual expand('%'), 'config/app.php'
+
+Execute (edit channel):
+  Echannel Example
+  AssertEqual expand('%'), 'app/Broadcasting/Example.php'
+
+Execute (edit controller):
+  Econtroller ExampleController
+  AssertEqual expand('%'), 'app/Http/Controllers/ExampleController.php'
+
+Execute (edit default controller):
+  Econtroller
+  AssertEqual expand('%'), 'app/Http/Controllers/Controller.php'
+
+Execute (edit mail):
+  Email Example
+  AssertEqual expand('%'), 'app/Mail/Example.php'
+
+Execute (edit middleware):
+  Emiddleware Example
+  AssertEqual expand('%'), 'app/Http/Middleware/Example.php'
+
+Execute (edit default middleware):
+  Emiddleware
+  AssertEqual expand('%'), 'app/Http/Kernel.php'
+
+Execute (edit request):
+  Erequest Example
+  AssertEqual expand('%'), 'app/Http/Requests/Example.php'
+
+Execute (edit resource):
+  Eresource Example
+  AssertEqual expand('%'), 'app/Http/Resources/Example.php'
+
+Execute (edit rule):
+  Erule Example
+  AssertEqual expand('%'), 'app/Rules/Example.php'
+
+Execute (edit event):
+  Eevent Example
+  AssertEqual expand('%'), 'app/Events/Example.php'
+
+Execute (edit default event):
+  Eevent
+  AssertEqual expand('%'), 'app/Events/Event.php'
+
+Execute (edit exception):
+  Eexception Example
+  AssertEqual expand('%'), 'app/Exceptions/Example.php'
+
+Execute (edit default exception):
+  Eexception
+  AssertEqual expand('%'), 'app/Exceptions/Handler.php'
+
+Execute (edit provider):
+  Eprovider Example
+  AssertEqual expand('%'), 'app/Providers/Example.php'
+
+Execute (edit factory):
+  Efactory Example
+  AssertEqual expand('%'), 'database/factories/Example.php'
+
+Execute (edit default factory):
+  Efactory
+  AssertEqual expand('%'), 'database/factories/ModelFactory.php'
+
+Execute (edit migration):
+  Emigration example
+  AssertEqual expand('%'), 'database/migrations/example.php'
+
+Execute (edit seeder):
+  Eseeder Example
+  AssertEqual expand('%'), 'database/seeds/Example.php'
+
+Execute (edit default seeder):
+  Eseeder
+  AssertEqual expand('%'), 'database/seeds/DatabaseSeeder.php'
+
+Execute (edit test):
+  Etest Example
+  AssertEqual expand('%'), 'tests/Example.php'
+
+Execute (edit default test):
+  Etest
+  AssertEqual expand('%'), 'tests/TestCase.php'
+
+Execute (edit language file):
+  Elanguage example
+  AssertEqual expand('%'), 'resources/lang/example.php'
+
+Execute (edit asset file):
+  Easset example.ext
+  AssertEqual expand('%'), 'resources/assets/example.ext'
+
+Execute (edit README):
+  Edoc
+  AssertEqual expand('%'), 'README.md'
+
+Execute (edit view):
+  Eview example
+  AssertEqual expand('%'), 'resources/views/example.blade.php'
+
+Execute (edit env file):
+  Eenv
+  AssertEqual expand('%'), '.env.example'
+
+Execute (edit job):
+  Ejob Example
+  AssertEqual expand('%'), 'app/Jobs/Example.php'
+
+Execute (edit default job):
+  Ejob
+  AssertEqual expand('%'), 'app/Jobs/Job.php'
+
+Execute (edit command):
+  Ecommand Example
+  AssertEqual expand('%'), 'app/Console/Commands/Example.php'
+
+Execute (edit default command):
+  Ecommand
+  AssertEqual expand('%'), 'app/Console/Kernel.php'
+
+Execute (edit listener):
+  Elistener Example
+  AssertEqual expand('%'), 'app/Listeners/Example.php'
+
+Execute (edit model):
+  Emodel Example
+  AssertEqual expand('%'), 'app/Models/Example.php'
+
+Execute (edit notification):
+  Enotification Example
+  AssertEqual expand('%'), 'app/Notifications/Example.php'
+
+Execute (edit policy):
+  Epolicy Example
+  AssertEqual expand('%'), 'app/Policies/Example.php'
+
+Execute (edit routes):
+  Eroutes example
+  AssertEqual expand('%'), 'routes/example.php'

--- a/test/not_in_project.vader
+++ b/test/not_in_project.vader
@@ -1,8 +1,5 @@
 Before (in a non-laravel buffer):
-  edit README.md
-
-After (clean up):
-  bdelete!
+  edit test/fixtures/.gitkeep
 
 Execute (projection commands are not defined):
   AssertThrows Econtroller

--- a/test/not_in_project.vader
+++ b/test/not_in_project.vader
@@ -1,10 +1,11 @@
 Before (in a non-laravel buffer):
   edit test/fixtures/.gitkeep
 
+Execute (Laravel root is not set):
+  AssertEqual exists('b:laravel_root'), 0
+
 Execute (projection commands are not defined):
-  AssertThrows Econtroller
-  AssertEqual g:vader_exception, 'Vim:E492: Not an editor command: Econtroller'
+  AssertEqual exists(':Econtroller'), 0
 
 Execute (the :Artisan command is not defined):
-  AssertThrows Artisan
-  AssertEqual g:vader_exception, 'Vim:E492: Not an editor command: Artisan'
+  AssertEqual exists(':Artisan'), 0

--- a/test/not_in_project.vader
+++ b/test/not_in_project.vader
@@ -1,0 +1,13 @@
+Before (in a non-laravel buffer):
+  edit README.md
+
+After (clean up):
+  bdelete!
+
+Execute (projection commands are not defined):
+  AssertThrows Econtroller
+  AssertEqual g:vader_exception, 'Vim:E492: Not an editor command: Econtroller'
+
+Execute (the :Artisan command is not defined):
+  AssertThrows Artisan
+  AssertEqual g:vader_exception, 'Vim:E492: Not an editor command: Artisan'


### PR DESCRIPTION
Testing vim-laravel is somewhat tricky because (a) it needs extensive fixture files (a Laravel project) and (b) has optional dependencies on other plug-ins, with fallback behavior in their absence.

- [x] Get basic smoke tests running on Travis CI
- [x] Set up fixture Laravel project (run `composer create-project` in CI)
- [ ] Test navigation commands
- [x] Test `:Artisan` commands, particularly `make:*`

From there, it would be nice to test against multiple Laravel/Lumen versions, test behavior with/without optional Vim dependencies, etc.